### PR TITLE
feat: require explicit secret path & support any secret engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A simple extension to [Pydantic][pydantic] [BaseSettings][pydantic-basesettings] that can retrieve secrets from a [KV v2 secrets engine][vault-kv-v2] in Hashicorp [Vault][vault]
 
+↖️ *Hint: look at the table of contents up there! (<svg aria-hidden="true" viewBox="0 0 16 16" version="1.1" data-view-component="true" height="16" width="16" class="octicon octicon-list-unordered">
+    <path fill-rule="evenodd" d="M2 4a1 1 0 100-2 1 1 0 000 2zm3.75-1.5a.75.75 0 000 1.5h8.5a.75.75 0 000-1.5h-8.5zm0 5a.75.75 0 000 1.5h8.5a.75.75 0 000-1.5h-8.5zm0 5a.75.75 0 000 1.5h8.5a.75.75 0 000-1.5h-8.5zM3 8a1 1 0 11-2 0 1 1 0 012 0zm-1 6a1 1 0 100-2 1 1 0 000 2z"></path>
+</svg> icon above the Readme on GitHub)*
+
 ## Getting started
 
 Starting with Pydantic 1.8, [custom settings sources][pydantic-basesettings-customsource] are officially supported.
@@ -19,14 +23,15 @@ from pydantic import BaseSettings, Field, SecretStr
 from pydantic_vault import vault_config_settings_source
 
 class Settings(BaseSettings):
-    username: str = Field(..., vault_secret_path="path/to/secret", vault_secret_key="my_user")
-    password: SecretStr = Field(..., vault_secret_path="path/to/secret", vault_secret_key="my_password")
+    # The `vault_secret_path` is the full path (with mount point included) to the secret
+    # The `vault_secret_key` is the specific key to extract from a secret
+    username: str = Field(..., vault_secret_path="secret/data/path/to/secret", vault_secret_key="my_user")
+    password: SecretStr = Field(..., vault_secret_path="secret/data/path/to/secret", vault_secret_key="my_password")
 
     class Config:
         vault_url: str = "https://vault.tld"
         vault_token: SecretStr = os.environ["VAULT_TOKEN"]
         vault_namespace: str = "your/namespace"  # Optional, pydantic-vault supports Vault namespaces (for Vault Enterprise)
-        vault_secret_mount_point: str = "secrets"  # Optional, if your KV v2 secrets engine is not available at the default "secret" mount point
 
         @classmethod
         def customise_sources(
@@ -69,13 +74,13 @@ The additional parameters Pydantic-Vault uses are:
 
 | Parameter name              | Required | Description |
 |-----------------------------|----------|-------------|
-| `vault_secret_path`         | **Yes**  | The path to your secret in Vault |
-| `vault_secret_key`          | **Yes**  | The key to use in the secret |
+| `vault_secret_path`         | **Yes**  | The path to your secret in Vault<br>This needs to be the *full path* to the secret, including its mount point (see [examples](#examples) below) |
+| `vault_secret_key`          | No       | The key to use in the secret<br>If it is not specified the whole secret content will be loaded as a dict (see [examples](#examples) below) |
 
-For example, if you create a secret `database/prod` with a key `password` and a value of `a secret password`, you would use
+For example, if you create a secret `database/prod` with a key `password` and a value of `a secret password` in a KV v2 secret engine mounted at the default `secret/` location, you would access it with
 
 ```python
-password: SecretStr = Field(..., vault_secret_path="database/prod", vault_secret_key="password")
+password: SecretStr = Field(..., vault_secret_path="secret/data/database/prod", vault_secret_key="password")
 ```
 
 ### Configuration
@@ -87,7 +92,6 @@ You can configure the behaviour of Pydantic-vault in your `Settings.Config` clas
 | `customise_sources()`      | **Yes**  | N/A                  | You need to implement this function to use Vault as a settings source, and choose the priority order you want |
 | `vault_url`                | **Yes**  | `VAULT_ADDR`         | Your Vault URL |
 | `vault_namespace`          | No       | `VAULT_NAMESPACE`    | Your Vault namespace (if you use one, requires Vault Enterprise) |
-| `vault_secret_mount_point` | No       | N/A                  | The mount point of the KV v2 secrets engine, if different from the default `"secret"` mount point |
 | `vault_auth_mount_point`   | No       | `VAULT_AUTH_MOUNT_POINT` | The mount point of the authentication method, if different from its default mount point |
 
 You can also configure everything available in the original Pydantic `BaseSettings` class.
@@ -273,6 +277,196 @@ class Settings(BaseSettings):
                 file_secret_settings
             )
 ```
+
+## Examples
+
+All examples use the following structure, so we will omit the imports and the `Config` inner class:
+```python
+from pydantic import BaseSettings, Field, SecretStr
+from pydantic_vault import vault_config_settings_source
+
+class Settings(BaseSettings):
+    ###############################################
+    # THIS PART CHANGES IN THE DIFFERENT EXAMPLES #
+    username: str = Field(..., vault_secret_path="secret/data/path/to/secret", vault_secret_key="my_user")
+    ###############################################
+
+    class Config:
+        vault_url: str = "https://vault.tld"
+
+        @classmethod
+        def customise_sources(
+                cls,
+                init_settings,
+                env_settings,
+                file_secret_settings,
+        ):
+            return (
+                init_settings,
+                env_settings,
+                vault_config_settings_source,
+                file_secret_settings
+            )
+```
+
+### Retrieve a secret from a KV v2 secret engine
+
+Suppose your secret is at `my-api/prod` and looks like this:
+```
+Key             Value
+---             -----
+root_user       root
+root_password   a_v3ry_s3cur3_p4ssw0rd
+```
+
+Your settings class would be:
+```python
+class Settings(BaseSettings):
+    # The `vault_secret_path` is the full path (with mount point included) to the secret.
+    # For a KV v2 secret engine, there is always a `data/` sub-path between the mount point and
+    # the secret actual path, eg. if your mount point is `secret/` (the default) and your secret
+    # path is `my-api/prod`, the full path to use is `secret/data/my-api/prod`.
+    # The `vault_secret_key` is the specific key to extract from a secret.
+    username: str = Field(..., vault_secret_path="secret/data/my-api/prod", vault_secret_key="root_user")
+    password: SecretStr = Field(..., vault_secret_path="secret/data/my-api/prod", vault_secret_key="root_password")
+
+settings = Settings()
+
+settings.username  # "root"
+settings.password.get_secret_value()  # "a_v3ry_s3cur3_p4ssw0rd"
+```
+
+### Retrieve a whole secret at once
+
+If you omit the `vault_secret_key` parameter in your `Field`, Pydantic-Vault will load
+the whole secret in your class field.
+
+With the same secret as before, located at `my-api/prod` and with this data:
+```
+Key             Value
+---             -----
+root_user       root
+root_password   a_v3ry_s3cur3_p4ssw0rd
+```
+
+You could use a settings class like this to retrieve everything in the secret:
+```python
+class Settings(BaseSettings):
+    # The `vault_secret_path` is the full path (with mount point included) to the secret.
+    # For a KV v2 secret engine, there is always a `data/` sub-path between the mount point and
+    # the secret actual path, eg. if your mount point is `secret/` (the default) and your secret
+    # path is `my-api/prod`, the full path to use is `secret/data/my-api/prod`.
+    # We don't pass a `vault_secret_key` here so that Pydantic-Vault fetches all fields at once.
+    credentials: dict = Field(..., vault_secret_path="secret/data/my-api/prod")
+
+settings = Settings()
+settings.credentials  # { "root_user": "root", "root_password": "a_v3ry_s3cur3_p4ssw0rd" }
+```
+
+You can also use a Pydantic `BaseModel` class to parse and validate the incoming secret:
+```python
+class Credentials(BaseModel):
+    root_user: str
+    root_password: SecretStr
+
+class Settings(BaseSettings):
+    # The `vault_secret_path` is the full path (with mount point included) to the secret.
+    # For a KV v2 secret engine, there is always a `data/` sub-path between the mount point and
+    # the secret actual path, eg. if your mount point is `secret/` (the default) and your secret
+    # path is `my-api/prod`, the full path to use is `secret/data/my-api/prod`.
+    # We don't pass a `vault_secret_key` here so that Pydantic-Vault fetches all fields at once.
+    credentials: Credentials = Field(..., vault_secret_path="secret/data/my-api/prod")
+
+settings = Settings()
+settings.credentials.root_user  # "root"
+settings.credentials.root_password.get_secret_value()  # "a_v3ry_s3cur3_p4ssw0rd"
+```
+
+### Retrieve a secret from a KV v1 secret engine
+
+Suppose your secret is at `my-api/prod` and looks like this:
+```
+Key             Value
+---             -----
+root_user       root
+root_password   a_v3ry_s3cur3_p4ssw0rd
+```
+
+Your settings class would be:
+```python
+class Settings(BaseSettings):
+    # The `vault_secret_path` is the full path (with mount point included) to the secret.
+    # For a KV v1 secret engine, the secret path is directly appended to the mount point,
+    # eg. if your mount point is `kv/` (the default) and your secret path is `my-api/prod`,
+    # the full path to use is `kv/my-api/prod` (unlike with KV v2 secret engines).
+    # The `vault_secret_key` is the specific key to extract from a secret.
+    username: str = Field(..., vault_secret_path="kv/my-api/prod", vault_secret_key="root_user")
+    password: SecretStr = Field(..., vault_secret_path="kv/my-api/prod", vault_secret_key="root_password")
+
+settings = Settings()
+
+settings.username  # "root"
+settings.password.get_secret_value()  # "a_v3ry_s3cur3_p4ssw0rd"
+```
+
+⚠ Beware of the [known limitations](#known-limitations) on KV v1 secrets!
+
+### Retrieve a secret from a database secret engine
+
+Database secrets can be "dynamic", generated by Vault every time you request access.
+Because every call to Vault will create a new database account, you cannot store the username
+and password in two different fields in your settings class, or you would get the username of the
+*first* generated account and the password of the *second* account. This means that you must *not*
+pass a `vault_secret_key`, so that Pydantic-Vault retrieves the whole secret at once.
+
+You can store the credentials in a dict or in a custom `BaseModel` class:
+```python
+class DbCredentials(BaseModel):
+    username: str
+    password: SecretStr
+
+
+class Settings(BaseSettings):
+    # The `vault_secret_path` is the full path (with mount point included) to the secret.
+    # For a database secret engine, the secret path is `<mount point>/creds/<role name>`.
+    # For example if your mount point is `database/` (the default) and your role name is
+    # `my-db-prod`, the full path to use is `database/creds/my-db-prod`. You will receive
+    # `username` and `password` fields in response.
+    # You must *not* pass a `vault_secret_key` so that Pydantic-Vault fetches both fields at once.
+    db_creds: DbCredentials = Field(..., vault_secret_path="database/creds/my-db-prod")
+    db_creds_in_dict: dict = Field(..., vault_secret_path="database/creds/my-db-prod")
+
+settings = Settings()
+
+settings.db_creds.username  # "generated-username-1"
+settings.db_creds.password.get_secret_value()  # "generated-password-for-username-1"
+settings.db_creds_in_dict["username"]  # "generated-username-2"
+settings.db_creds_in_dict["password"]  # "generated-password-for-username-2"
+```
+
+## Known limitations
+
+- On KV v1 secret engines, if your secret has a `data` key and you do not specify a `vault_secret_key`
+to load the whole secret at once, Pydantic-vault will only load the content of the `data` key.
+  For example, with a secret `kv/my-secret`
+  ```
+  Key             Value
+  ---             -----
+  user            root
+  password        a_v3ry_s3cur3_p4ssw0rd
+  data            a very important piece of data
+  ```
+  and the settings class
+  ```python
+  class Settings(BaseSettings):
+      my_secret: dict = Field(..., vault_secret_path="kv/my-secret")
+  ```
+  Pydantic-Vault will try to load only the `data` value (`a very important piece of data`) in
+  `my_secret`, which will fail validation from Pydantic because it is not a dict.
+
+  **Workaround:** Rename the `data` key in your secret 😅
+
+  **Workaround:** Migrate to KV v2
 
 ## Inspirations
 

--- a/src/pydantic_vault/vault_settings.py
+++ b/src/pydantic_vault/vault_settings.py
@@ -213,8 +213,11 @@ def vault_config_settings_source(settings: BaseSettings) -> Dict[str, Any]:
             try:
                 vault_val = settings.__config__.json_loads(vault_val)  # type: ignore
             except ValueError as e:
+                secret_full_path = vault_secret_path
+                if vault_secret_key is not None:
+                    secret_full_path += f":{vault_secret_key}"
                 raise SettingsError(
-                    f'error parsing JSON for "{vault_secret_path}{":" + vault_secret_key if vault_secret_key is not None else ""}"'
+                    f'error parsing JSON for "{secret_full_path}"'
                 ) from e
 
         d[field.alias] = vault_val

--- a/src/pydantic_vault/vault_settings.py
+++ b/src/pydantic_vault/vault_settings.py
@@ -167,13 +167,13 @@ def _extract_kubernetes() -> Optional[SecretStr]:
 
 
 def vault_config_settings_source(settings: BaseSettings) -> Dict[str, Any]:
-    d: Dict[str, Optional[str]] = {}
+    d: Dict[str, Any] = {}
 
     vault_client = _get_authenticated_vault_client(settings)
 
     # Get secrets
     for field in settings.__fields__.values():
-        vault_val: Union[str, dict]
+        vault_val: Union[str, Dict[str, Any]]
 
         vault_secret_path: Optional[str] = field.field_info.extra.get(
             "vault_secret_path"

--- a/src/pydantic_vault/vault_settings.py
+++ b/src/pydantic_vault/vault_settings.py
@@ -2,7 +2,7 @@ import logging
 import os
 from contextlib import suppress
 from pathlib import Path
-from typing import Dict, Optional, Any, NamedTuple
+from typing import Dict, Optional, Any, NamedTuple, Union
 
 from hvac import Client as HvacClient
 from hvac.exceptions import VaultError
@@ -173,39 +173,48 @@ def vault_config_settings_source(settings: BaseSettings) -> Dict[str, Any]:
 
     # Get secrets
     for field in settings.__fields__.values():
-        vault_val: Optional[str] = None
+        vault_val: Union[str, dict]
 
-        vault_secret_path = field.field_info.extra.get("vault_secret_path")
-        vault_secret_key = field.field_info.extra.get("vault_secret_key")
+        vault_secret_path: Optional[str] = field.field_info.extra.get(
+            "vault_secret_path"
+        )
+        vault_secret_key: Optional[str] = field.field_info.extra.get("vault_secret_key")
 
-        if vault_secret_path is None or vault_secret_key is None:
+        if vault_secret_path is None:
             logging.debug(f"Skipping field {field.name}")
             continue
 
-        vault_secret_mount_point = getattr(
-            settings.__config__, "vault_secret_mount_point", None
-        )
-
-        read_secret_parameters: HvacReadSecretParameters = {"path": vault_secret_path}
-        if vault_secret_mount_point is not None:
-            read_secret_parameters["mount_point"] = vault_secret_mount_point
-
         try:
-            vault_val = vault_client.secrets.kv.v2.read_secret_version(
-                **read_secret_parameters
-            )["data"]["data"][vault_secret_key]
+            vault_api_response = vault_client.read(vault_secret_path)["data"]
         except VaultError:
-            logging.info(
-                f'could not get secret "{vault_secret_path}:{vault_secret_key}"'
-            )
+            logging.info(f'could not get secret "{vault_secret_path}"')
             continue
 
-        if field.is_complex():
+        if vault_secret_key is None:
+            try:
+                vault_val = vault_api_response["data"]
+            except KeyError:
+                vault_val = vault_api_response
+        else:
+            try:
+                vault_val = vault_api_response["data"][vault_secret_key]
+            except KeyError:
+                try:
+                    vault_val = vault_api_response[vault_secret_key]
+                except KeyError:
+                    logging.info(
+                        f'could not get key "{vault_secret_key}" in secret "{vault_secret_path}"'
+                    )
+                    continue
+
+        if field.is_complex() and not isinstance(
+            vault_val, dict
+        ):  # If it is already a dict we can load it in Pydantic
             try:
                 vault_val = settings.__config__.json_loads(vault_val)  # type: ignore
             except ValueError as e:
                 raise SettingsError(
-                    f'error parsing JSON for "{vault_secret_path}:{vault_secret_key}'
+                    f'error parsing JSON for "{vault_secret_path}{":" + vault_secret_key if vault_secret_key is not None else ""}"'
                 ) from e
 
         d[field.alias] = vault_val

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+from pytest import MonkeyPatch
+from pyfakefs.fake_filesystem import FakeFilesystem
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.delenv("VAULT_TOKEN", raising=False)
+    monkeypatch.delenv("VAULT_ADDR", raising=False)
+    monkeypatch.delenv("VAULT_ROLE_ID", raising=False)
+    monkeypatch.delenv("VAULT_SECRET_ID", raising=False)
+    monkeypatch.delenv("VAULT_KUBERNETES_ROLE", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def mock_filesystem(fs: FakeFilesystem) -> None:
+    pass

--- a/tests/test_get_vault_client.py
+++ b/tests/test_get_vault_client.py
@@ -10,20 +10,6 @@ from pydantic_vault import VaultParameterError
 from pydantic_vault.vault_settings import _get_authenticated_vault_client
 
 
-@pytest.fixture(autouse=True)
-def clean_env(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.delenv("VAULT_TOKEN", raising=False)
-    monkeypatch.delenv("VAULT_ADDR", raising=False)
-    monkeypatch.delenv("VAULT_ROLE_ID", raising=False)
-    monkeypatch.delenv("VAULT_SECRET_ID", raising=False)
-    monkeypatch.delenv("VAULT_KUBERNETES_ROLE", raising=False)
-
-
-@pytest.fixture(autouse=True)
-def mock_filesystem(fs: FakeFilesystem) -> None:
-    pass
-
-
 @pytest.fixture
 def mock_vault_token_from_file(fs: FakeFilesystem) -> str:
     """Return the token written in the .vault-token file"""

--- a/tests/test_settings_source.py
+++ b/tests/test_settings_source.py
@@ -1,56 +1,89 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
+from typing_extensions import TypedDict
 from unittest.mock import MagicMock
 
 from hvac.exceptions import VaultError
-from pydantic import BaseSettings, Field, SecretStr
+from pydantic import BaseSettings, Field, SecretStr, BaseModel
 import pytest
 from pytest_mock import MockerFixture
 
 from pydantic_vault import vault_config_settings_source
 
-VaultStructure = Dict[str, Dict[str, Any]]
-VaultResponseDict = Dict[str, Dict[str, Dict[str, Any]]]
+
+class VaultDataWrapper(TypedDict):
+    data: Dict[str, Any]
 
 
-def fake_vault(path: str, mount_point: str = "secrets") -> VaultResponseDict:
+VaultStructure = Dict[str, VaultDataWrapper]
+
+
+def fake_vault(path: str) -> VaultDataWrapper:
     vault: VaultStructure = {
-        "first_level_key": {
-            "username": "my_user",
-            "password": "my_password",
-            "complex_value": {
-                "inner": "value",
-                "int_key": 12,
-                "list_key": ["first", "second", "third"],
-            },
+        # Database secret engine
+        "database/creds/db_role": {
+            "data": {"username": "db_username", "password": "db_password"}
         },
-        "nested/path": {"username": "my_nested_username"},
+        # KV v1 secret engine
+        "kv/normal_secret": {"data": {"kvv1_key": "kvv1_value"}},
+        "kv/secret_with_data_key": {
+            "data": {
+                "kvv1_key": "kvv1_value",
+                "data": {"kvv1_nested_key": "kvv1_nested_value"},
+            }
+        },
+        # KV v2 secret engine
+        "secret/data/first_level_key": {
+            "data": {
+                "metadata": {},
+                "data": {
+                    "username": "kvv2_user",
+                    "password": "kvv2_password",
+                    "complex_value": {
+                        "inner": "value",
+                        "int_key": 12,
+                        "list_key": ["first", "second", "third"],
+                    },
+                    "json_in_string": '{"key": "value", "list": [1, 2, 3]}',
+                },
+            }
+        },
+        "secret/data/secret_with_data_key": {
+            "data": {
+                "metadata": {},
+                "data": {"data": {"kvv2_nested_key": "kvv2_nested_value"}},
+            }
+        },
+        "secret/data/nested/path": {
+            "data": {"metadata": {}, "data": {"username": "kvv2_nested_username"}}
+        },
     }
     try:
-        return {"data": {"data": vault[path]}}
+        return vault[path]
     except KeyError:
         raise VaultError(f"Key {path} not found in Vault")
 
 
 @pytest.fixture(autouse=True, name="fake_hvac_client")
 def bypass_hvac_client(mocker: MockerFixture) -> MagicMock:
-    mock_hvac_client = mocker.patch(
+    mock_hvac_client_constructor = mocker.patch(
         "pydantic_vault.vault_settings.HvacClient", autospec=True
     )
-    return mock_hvac_client.return_value
+    mock_hvac_client = mock_hvac_client_constructor.return_value
+    mock_hvac_client.read.side_effect = fake_vault
+
+    return mock_hvac_client
 
 
-def test_get_vault_secrets(fake_hvac_client: MagicMock) -> None:
-    fake_hvac_client.secrets.kv.v2.read_secret_version.side_effect = fake_vault
-
+def test_get_vault_secrets() -> None:
     class Settings(BaseSettings):
         username: str = Field(
             "doesn't matter",
-            vault_secret_path="first_level_key",
+            vault_secret_path="secret/data/first_level_key",
             vault_secret_key="username",
         )
         password: SecretStr = Field(
             "doesn't matter",
-            vault_secret_path="first_level_key",
+            vault_secret_path="secret/data/first_level_key",
             vault_secret_key="password",
         )
 
@@ -61,7 +94,7 @@ def test_get_vault_secrets(fake_hvac_client: MagicMock) -> None:
     settings = Settings()
 
     vault_settings_dict = vault_config_settings_source(settings)
-    assert vault_settings_dict == {"username": "my_user", "password": "my_password"}
+    assert vault_settings_dict == {"username": "kvv2_user", "password": "kvv2_password"}
 
 
 def test_do_not_search_vault_for_keys_not_configured() -> None:
@@ -69,7 +102,7 @@ def test_do_not_search_vault_for_keys_not_configured() -> None:
         simple_field: str = "doesn't matter"
         field_from_vault: str = Field(
             "doesn't matter",
-            vault_secret_path="first_level_key",
+            vault_secret_path="secret/data/first_level_key",
             vault_secret_key="password",
         )
 
@@ -80,17 +113,14 @@ def test_do_not_search_vault_for_keys_not_configured() -> None:
     settings = Settings()
 
     vault_settings_dict = vault_config_settings_source(settings)
-    assert "field_from_vault" in vault_settings_dict
-    assert "simple_field" not in vault_settings_dict
+    assert vault_settings_dict == {"field_from_vault": "kvv2_password"}
 
 
-def test_do_not_override_keys_not_found(fake_hvac_client: MagicMock) -> None:
-    fake_hvac_client.secrets.kv.v2.read_secret_version.side_effect = fake_vault
-
+def test_do_not_override_keys_not_found() -> None:
     class Settings(BaseSettings):
         field_from_vault: str = Field(
             "doesn't matter",
-            vault_secret_path="first_level_key",
+            vault_secret_path="secret/data/first_level_key",
             vault_secret_key="password",
         )
         field_not_found: str = Field(
@@ -110,3 +140,117 @@ def test_do_not_override_keys_not_found(fake_hvac_client: MagicMock) -> None:
     assert "field_not_found" not in vault_settings_dict
 
     assert settings.field_not_found == "default_value"
+
+
+def test_get_secret_without_key() -> None:
+    class DbCredentials(BaseModel):
+        username: str
+        password: SecretStr
+
+    class Settings(BaseSettings):
+        db_credentials: DbCredentials = Field(
+            {"username": "doesn't matter", "password": "doesn't matter"},
+            vault_secret_path="database/creds/db_role",
+        )
+        kvv2_secret: dict = Field({}, vault_secret_path="secret/data/first_level_key")
+
+        class Config:
+            vault_url: str = "https://vault.tld"
+            vault_token: SecretStr = SecretStr("fake-token")
+
+    settings = Settings()
+
+    vault_settings_dict = vault_config_settings_source(settings)
+    assert vault_settings_dict == {
+        "db_credentials": {"username": "db_username", "password": "db_password"},
+        "kvv2_secret": {
+            "username": "kvv2_user",
+            "password": "kvv2_password",
+            "complex_value": {
+                "inner": "value",
+                "int_key": 12,
+                "list_key": ["first", "second", "third"],
+            },
+            "json_in_string": '{"key": "value", "list": [1, 2, 3]}',
+        },
+    }
+
+
+def test_get_secrets_from_different_mount_points() -> None:
+    class Settings(BaseSettings):
+        field_from_kvv1: str = Field(
+            "doesn't matter",
+            vault_secret_path="kv/normal_secret",
+            vault_secret_key="kvv1_key",
+        )
+
+        field_from_kvv2: str = Field(
+            "doesn't matter",
+            vault_secret_path="secret/data/first_level_key",
+            vault_secret_key="username",
+        )
+
+        class Config:
+            vault_url: str = "https://vault.tld"
+            vault_token: SecretStr = SecretStr("fake-token")
+
+    settings = Settings()
+
+    vault_settings_dict = vault_config_settings_source(settings)
+    assert vault_settings_dict == {
+        "field_from_kvv1": "kvv1_value",
+        "field_from_kvv2": "kvv2_user",
+    }
+
+
+def test_get_secret_jsonified() -> None:
+    class JsonField(BaseModel):
+        key: str
+        list: List[int]
+
+    class Settings(BaseSettings):
+        json_field: JsonField = Field(
+            {"key": "doesn't matter", "list": []},
+            vault_secret_path="secret/data/first_level_key",
+            vault_secret_key="json_in_string",
+        )
+
+        class Config:
+            vault_url: str = "https://vault.tld"
+            vault_token: SecretStr = SecretStr("fake-token")
+
+    settings = Settings()
+
+    vault_settings_dict = vault_config_settings_source(settings)
+    assert vault_settings_dict == {"json_field": {"key": "value", "list": [1, 2, 3]}}
+
+
+def test_get_secret_in_data_key() -> None:
+    class Settings(BaseSettings):
+        kvv1_data_with_key: dict = Field(
+            {}, vault_secret_path="kv/secret_with_data_key", vault_secret_key="data"
+        )
+        # FIXME: KV v1 secret with a `data` key and configured without a
+        #        vault_secret_key is currently not supported
+        kvv2_data_with_key: dict = Field(
+            {},
+            vault_secret_path="secret/data/secret_with_data_key",
+            vault_secret_key="data",
+        )
+        kvv2_data_without_key: dict = Field(
+            {},
+            vault_secret_path="secret/data/secret_with_data_key",
+        )
+
+        class Config:
+            vault_url: str = "https://vault.tld"
+            vault_token: SecretStr = SecretStr("fake-token")
+
+    settings = Settings()
+
+    vault_settings_dict = vault_config_settings_source(settings)
+    assert vault_settings_dict == {
+        "kvv1_data_with_key": {"kvv1_nested_key": "kvv1_nested_value"},
+        "kvv2_data_with_key": {"kvv2_nested_key": "kvv2_nested_value"},
+        "kvv2_data_without_key": {"data": {"kvv2_nested_key": "kvv2_nested_value"}},
+    }

--- a/tests/test_settings_source.py
+++ b/tests/test_settings_source.py
@@ -116,16 +116,21 @@ def test_do_not_search_vault_for_keys_not_configured() -> None:
     assert vault_settings_dict == {"field_from_vault": "kvv2_password"}
 
 
-def test_do_not_override_keys_not_found() -> None:
+def test_do_not_override_default_value_if_secret_is_not_found() -> None:
     class Settings(BaseSettings):
         field_from_vault: str = Field(
             "doesn't matter",
             vault_secret_path="secret/data/first_level_key",
             vault_secret_key="password",
         )
-        field_not_found: str = Field(
+        path_not_found: str = Field(
             "default_value",
             vault_secret_path="not/found",
+            vault_secret_key="does_not_matter",
+        )
+        key_not_found: str = Field(
+            "default_value",
+            vault_secret_path="secret/data/first_level_key",
             vault_secret_key="does_not_exist",
         )
 
@@ -137,9 +142,11 @@ def test_do_not_override_keys_not_found() -> None:
 
     vault_settings_dict = vault_config_settings_source(settings)
     assert "field_from_vault" in vault_settings_dict
-    assert "field_not_found" not in vault_settings_dict
+    assert "path_not_found" not in vault_settings_dict
+    assert "key_not_found" not in vault_settings_dict
 
-    assert settings.field_not_found == "default_value"
+    assert settings.path_not_found == "default_value"
+    assert settings.key_not_found == "default_value"
 
 
 def test_get_secret_without_key() -> None:

--- a/tests/test_settings_source.py
+++ b/tests/test_settings_source.py
@@ -152,7 +152,9 @@ def test_get_secret_without_key() -> None:
             {"username": "doesn't matter", "password": "doesn't matter"},
             vault_secret_path="database/creds/db_role",
         )
-        kvv2_secret: dict = Field({}, vault_secret_path="secret/data/first_level_key")
+        kvv2_secret: Dict[str, Any] = Field(
+            {}, vault_secret_path="secret/data/first_level_key"
+        )
 
         class Config:
             vault_url: str = "https://vault.tld"
@@ -227,17 +229,17 @@ def test_get_secret_jsonified() -> None:
 
 def test_get_secret_in_data_key() -> None:
     class Settings(BaseSettings):
-        kvv1_data_with_key: dict = Field(
+        kvv1_data_with_key: Dict[str, Any] = Field(
             {}, vault_secret_path="kv/secret_with_data_key", vault_secret_key="data"
         )
         # FIXME: KV v1 secret with a `data` key and configured without a
         #        vault_secret_key is currently not supported
-        kvv2_data_with_key: dict = Field(
+        kvv2_data_with_key: Dict[str, Any] = Field(
             {},
             vault_secret_path="secret/data/secret_with_data_key",
             vault_secret_key="data",
         )
-        kvv2_data_without_key: dict = Field(
+        kvv2_data_without_key: Dict[str, Any] = Field(
             {},
             vault_secret_path="secret/data/secret_with_data_key",
         )


### PR DESCRIPTION
This allows to use different secret mount points in the same configuration, as well as support engines other than KV v2.
With it also comes the possibility to load an entire secret at once, by not passing a `vault_secret_key`.

BREAKING CHANGE: This requires that you explicitely pass the full secret path, eg. `secret/data/<path/to/secret>` for a KV v2, or `database/creds/<your DB role>` for a database engine.