### PR TITLE
feat: relax hvac version constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+Thank you, @area42, for your contribution!
+
 ### Breaking changes
 **Drop support of Python 3.6.**
-Recent versions of dev dependencies require 3.7 or more, and some have even started to drop 3.7.
+Recent versions of dependencies (`hvac` and other dev dependencies) require 3.7 or more, and some have even started to drop 3.7.
 I hope it won't hurt many, as Python 3.6 is unsupported since December 2021.
 The code hasn't changed yet, so it should still run on 3.6, we don't test it anymore though ^^'
+
+### Added
+- Support `hvac` 1.X (relaxed the upper constraint on `hvac`). Initially proposed by @area42 in #18, I just reapplied the change on top of the new main to avoid conflicts
 
 ### Internal
 - Bump all dev dependencies and Actions

--- a/poetry.lock
+++ b/poetry.lock
@@ -299,21 +299,18 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "diff-cover (>=7.5)", "p
 
 [[package]]
 name = "hvac"
-version = "0.11.2"
+version = "1.1.1"
 description = "HashiCorp Vault API client"
 optional = false
-python-versions = ">=2.7"
+python-versions = ">=3.6.2,<4.0.0"
 files = [
-    {file = "hvac-0.11.2-py2.py3-none-any.whl", hash = "sha256:3e8a34804b1e20954a2b4991cc13ed9c09b32e50dadd9d3438224481150f6568"},
-    {file = "hvac-0.11.2.tar.gz", hash = "sha256:f905c59d32d88d3f67571fe5a8a78de4659e04798ad809de439f667247d13626"},
+    {file = "hvac-1.1.1-py3-none-any.whl", hash = "sha256:466e883665b4082933106b292649f9fba3bc0709a1ec1729e9e35b29477164b3"},
+    {file = "hvac-1.1.1.tar.gz", hash = "sha256:f9dbcc46b98b250c785eb1050aa11ee34a0c8b6616b75218cf1346a9817992f9"},
 ]
 
 [package.dependencies]
-requests = ">=2.21.0"
-six = ">=1.5.0"
-
-[package.extras]
-parser = ["pyhcl (>=0.3.10)"]
+pyhcl = ">=0.4.4,<0.5.0"
+requests = ">=2.27.1,<3.0.0"
 
 [[package]]
 name = "identify"
@@ -601,6 +598,16 @@ files = [
 ]
 
 [[package]]
+name = "pyhcl"
+version = "0.4.4"
+description = "HCL configuration parser for python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pyhcl-0.4.4.tar.gz", hash = "sha256:2d9b9dcdf1023d812bfed561ba72c99104c5b3f52e558d595130a44ce081b003"},
+]
+
+[[package]]
 name = "pytest"
 version = "7.4.0"
 description = "pytest: simple powerful testing with Python"
@@ -745,17 +752,6 @@ testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[l
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
-name = "six"
-version = "1.16.0"
-description = "Python 2 and 3 compatibility utilities"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-files = [
-    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
-    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
-]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -883,4 +879,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "49c53b31c11b1f76ec7ed3dc6d3d6ad0ce5be79ca6c2c155ae0b49a69d991fac"
+content-hash = "dc169b96a717af2515f51853450f250c3626872e53f020829e4448e79408d6d0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.7"
 pydantic = "^1.8"
-hvac = ">=0.10.6, <0.12"
+hvac = ">=0.10.6"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^2.21"


### PR DESCRIPTION
Because we are a library and not an end application, we need to relax our dependencies, so that our users have the most leeway to choose the version of our sub-dependencies that they want (for example if they have hvac as a direct dependency or if another of their dependencies has hvac as a sub-dependency).
By leaving the upper constraint open (we just want hvac >= 0.10.6), users can keep the "old" version they already had, or use a newer version if they want/have to (because of a sub-dependency). If a later hvac version breaks pydantic-vault, user can always pin the sub-dependency version to something that works with all their dependencies...

This was initially implemented by @area42 in PR #18, I redid it on top of the new main branch because I changed all other dependency versions and there was too many conflicts ^^' Thank you for your contribution!

Supersedes: #18