### PR TITLE
feat!: change config source priorities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes
+**Field value priority change**
+
+Initially, values in a Config class took higher priority over environment variables, effectively making it hard to override hardcoded defaults
+outside of the source code. This release addresses this inconvenience and makes the ordering consistent with [Pydantic](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#field-value-priority) and [12 Factor App](https://12factor.net/config).
+
 ## [0.8.0] - 2023-09-10
 Thank you, @area42 and @raider444, for your contributions!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Thank you, @kazauwa, for your contribution!
+
 ### Breaking changes
 **Field value priority change**
 
 Initially, values in a Config class took higher priority over environment variables, effectively making it hard to override hardcoded defaults
-outside of the source code. This release addresses this inconvenience and makes the ordering consistent with [Pydantic](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#field-value-priority) and [12 Factor App](https://12factor.net/config).
+outside the source code. This release addresses this inconvenience and makes the ordering consistent with [Pydantic](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#field-value-priority) and [12 Factor App](https://12factor.net/config).
+
+### Changed
+
+- BREAKING: Make environment variables override what is defined in the Config, contrary to the previous behaviour (#25)
+
 
 ## [0.8.0] - 2023-09-10
 Thank you, @area42 and @raider444, for your contributions!

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ You can configure the behaviour of Pydantic-vault in your `Settings.Config` clas
 | `vault_auth_mount_point`   | `str \| None`         | No       | `VAULT_AUTH_MOUNT_POINT` | The mount point of the authentication method, if different from its default mount point                                          |
 | `vault_certificate_verify` | `str \| bool \| None` | No       | `VAULT_CA_BUNDLE`        | The path to a CA bundle validating your Vault certificate, or `False` to disable verification (see [hvac docs][hvac-private-ca]) |
 
+Environment variables override what has been defined in the `Config` class.
+
 You can also configure everything available in the original Pydantic `BaseSettings` class.
 
 ### Authentication
@@ -171,8 +173,8 @@ Support is planned for GKE authentication methods.
 To authenticate using the [Approle auth method][vault-auth-approle], you need to pass a role ID and a secret ID to your Settings class.
 
 Pydantic-vault reads this information from the following sources (in descending order of priority):
-  - the `vault_role_id` and `vault_secret_id` configuration fields in your `Settings.Config` class (`vault_secret_id` can be a `str` or a `SecretStr`)
-  - the `VAULT_ROLE_ID` and `VAULT_SECRET_ID` environment variables
+- the `VAULT_ROLE_ID` and `VAULT_SECRET_ID` environment variables
+- the `vault_role_id` and `vault_secret_id` configuration fields in your `Settings.Config` class (`vault_secret_id` can be a `str` or a `SecretStr`)
 
 You can also mix-and-match, e.g. write the role ID in your `Settings.Config` class and retrieve the secret ID from the environment at runtime.
 
@@ -215,8 +217,8 @@ class Settings(BaseSettings):
 To authenticate using the [Kubernetes auth method][vault-auth-kubernetes], you need to pass a role to your Settings class.
 
 Pydantic-vault reads this information from the following sources (in descending order of priority):
-  - the `vault_kubernetes_role` configuration field in your `Settings.Config` class, which must be a `str`
-  - the `VAULT_KUBERNETES_ROLE` environment variable
+- the `VAULT_KUBERNETES_ROLE` environment variable
+- the `vault_kubernetes_role` configuration field in your `Settings.Config` class, which must be a `str`
 
 The Kubernetes service account token will be read from the file at `/var/run/secrets/kubernetes.io/serviceaccount/token`.
 
@@ -257,10 +259,10 @@ class Settings(BaseSettings):
 
 To authenticate using the [Token auth method][vault-auth-token], you need to pass a Vault token to your `Settings` class.
 
-Pydantic-vault reads this token from the following sources (in descending order of priority):
-  - the `vault_token` configuration field in your `Settings.Config` class, which can be a `str` or a `SecretStr`
-  - the `VAULT_TOKEN` environment variable
-  - the `~/.vault-token` file (so you can use the `vault` CLI to login locally, Pydantic-vault will transparently reuse its token)
+Pydantic-Vault reads this token from the following sources (in descending order of priority):
+- the `VAULT_TOKEN` environment variable
+- the `~/.vault-token` file (so you can use the `vault` CLI to login locally, Pydantic-Vault will transparently reuse its token)
+- the `vault_token` configuration field in your `Settings.Config` class, which can be a `str` or a `SecretStr`
 
 Example:
 ```python

--- a/src/pydantic_vault/vault_settings.py
+++ b/src/pydantic_vault/vault_settings.py
@@ -61,31 +61,37 @@ def _get_authenticated_vault_client(settings: BaseSettings) -> Optional[HvacClie
 
     # URL
     _vault_url: Optional[str] = None
-    if "VAULT_ADDR" in os.environ:
-        _vault_url = os.environ["VAULT_ADDR"]
-        logger.debug(f"Found Vault Address '{_vault_url}' in environment variables")
     if getattr(settings.__config__, "vault_url", None) is not None:
         _vault_url = settings.__config__.vault_url  # type: ignore
         logger.debug(f"Found Vault Address '{_vault_url}' in Config")
+    if "VAULT_ADDR" in os.environ:
+        _vault_url = os.environ["VAULT_ADDR"]
+        logger.debug(f"Found Vault Address '{_vault_url}' in environment variables")
     if _vault_url is None:
         raise VaultParameterError("No URL provided to connect to Vault")
 
     # Namespace
     _vault_namespace: Optional[str] = None
+    if getattr(settings.__config__, "vault_namespace", None) is not None:
+        _vault_namespace = cast(str, settings.__config__.vault_namespace)  # type: ignore
+        hvac_parameters.update({"namespace": _vault_namespace})
+        logger.debug(f"Found Vault Namespace '{_vault_namespace}' in Config")
     if "VAULT_NAMESPACE" in os.environ:
         _vault_namespace = os.environ["VAULT_NAMESPACE"]
         hvac_parameters.update({"namespace": _vault_namespace})
         logger.debug(
             f"Found Vault Namespace '{_vault_namespace}' in environment variables"
         )
-    if getattr(settings.__config__, "vault_namespace", None) is not None:
-        _vault_namespace = cast(str, settings.__config__.vault_namespace)  # type: ignore
-        hvac_parameters.update({"namespace": _vault_namespace})
-        logger.debug(f"Found Vault Namespace '{_vault_namespace}' in Config")
 
     # Certificate verification
+    if getattr(settings.__config__, "vault_certificate_verify", None) is not None:
+        _vault_certificate_verify: Union[bool, str] = cast(
+            Union[bool, str], settings.__config__.vault_certificate_verify  # type: ignore
+        )
+        hvac_parameters.update({"verify": _vault_certificate_verify})
+        logger.debug(f"Found Vault CA bundle '{_vault_certificate_verify}' in Config")
     if "VAULT_CA_BUNDLE" in os.environ:
-        _vault_certificate_verify: Union[bool, str] = os.environ["VAULT_CA_BUNDLE"]
+        _vault_certificate_verify = os.environ["VAULT_CA_BUNDLE"]
         try:
             hvac_parameters.update(
                 {"verify": parse_obj_as(bool, _vault_certificate_verify)}
@@ -95,26 +101,20 @@ def _get_authenticated_vault_client(settings: BaseSettings) -> Optional[HvacClie
         logger.debug(
             f"Found Vault CA bundle '{_vault_certificate_verify}' in environment variables"
         )
-    if getattr(settings.__config__, "vault_certificate_verify", None) is not None:
-        _vault_certificate_verify = cast(
-            Union[bool, str], settings.__config__.vault_certificate_verify  # type: ignore
-        )
-        hvac_parameters.update({"verify": _vault_certificate_verify})
-        logger.debug(f"Found Vault CA bundle '{_vault_certificate_verify}' in Config")
 
     # Auth method parameters
     _vault_auth_method_parameters: AuthMethodParameters = {}
-    if "VAULT_AUTH_MOUNT_POINT" in os.environ:
-        _vault_auth_mount_point = os.environ["VAULT_AUTH_MOUNT_POINT"]
-        _vault_auth_method_parameters["mount_point"] = _vault_auth_mount_point
-        logger.debug(
-            f"Found Vault Auth mount point '{_vault_auth_mount_point}' in environment variables"
-        )
     if getattr(settings.__config__, "vault_auth_mount_point", None) is not None:
         _vault_auth_mount_point: str = settings.__config__.vault_auth_mount_point  # type: ignore
         _vault_auth_method_parameters["mount_point"] = _vault_auth_mount_point
         logger.debug(
             f"Found Vault Auth mount point '{_vault_auth_mount_point}' in Config"
+        )
+    if "VAULT_AUTH_MOUNT_POINT" in os.environ:
+        _vault_auth_mount_point = os.environ["VAULT_AUTH_MOUNT_POINT"]
+        _vault_auth_method_parameters["mount_point"] = _vault_auth_mount_point
+        logger.debug(
+            f"Found Vault Auth mount point '{_vault_auth_mount_point}' in environment variables"
         )
 
     _vault_token = _extract_vault_token(settings)
@@ -176,15 +176,7 @@ def _extract_approle(settings: BaseSettings) -> Optional[Approle]:
     _vault_role_id: Optional[str] = None
     _vault_secret_id: Optional[SecretStr] = None
 
-    # Load from environment
-    if "VAULT_ROLE_ID" in os.environ:
-        _vault_role_id = os.environ["VAULT_ROLE_ID"]
-        logger.debug(f"Found Vault Role ID '{_vault_role_id}' in environment variables")
-    if "VAULT_SECRET_ID" in os.environ:
-        _vault_secret_id = SecretStr(os.environ["VAULT_SECRET_ID"])
-        logger.debug("Found Vault Secret ID in environment variables")
-
-    # Load (and eventually override) from BaseSettings.Config
+    # Load from BaseSettings.Config
     if getattr(settings.__config__, "vault_role_id", None) is not None:
         _vault_role_id = settings.__config__.vault_role_id  # type: ignore
         logger.debug(f"Found Vault Role ID '{_vault_role_id}' in Config")
@@ -195,6 +187,14 @@ def _extract_approle(settings: BaseSettings) -> Optional[Approle]:
             _vault_secret_id = SecretStr(settings.__config__.vault_secret_id)  # type: ignore
         logger.debug(f"Found Vault Secret ID in Config")
 
+    # Load (and eventually override) from environment
+    if "VAULT_ROLE_ID" in os.environ:
+        _vault_role_id = os.environ["VAULT_ROLE_ID"]
+        logger.debug(f"Found Vault Role ID '{_vault_role_id}' in environment variables")
+    if "VAULT_SECRET_ID" in os.environ:
+        _vault_secret_id = SecretStr(os.environ["VAULT_SECRET_ID"])
+        logger.debug("Found Vault Secret ID in environment variables")
+
     if _vault_role_id is not None and _vault_secret_id is not None:
         return Approle(role_id=_vault_role_id, secret_id=_vault_secret_id)
 
@@ -204,17 +204,17 @@ def _extract_approle(settings: BaseSettings) -> Optional[Approle]:
 def _extract_vault_token(settings: BaseSettings) -> Optional[SecretStr]:
     """Extract Vault token from environment, from .vault-token file or from BaseSettings.Config"""
     _vault_token: SecretStr
+    if "VAULT_TOKEN" in os.environ:
+        _vault_token = SecretStr(os.environ["VAULT_TOKEN"])
+        logger.debug("Found Vault Token in environment variables")
+        return _vault_token
+
     if getattr(settings.__config__, "vault_token", None) is not None:
         if isinstance(settings.__config__.vault_token, SecretStr):  # type: ignore
             _vault_token = settings.__config__.vault_token  # type: ignore
         else:
             _vault_token = SecretStr(settings.__config__.vault_token)  # type: ignore
         logger.debug("Found Vault Token in Config")
-        return _vault_token
-
-    if "VAULT_TOKEN" in os.environ:
-        _vault_token = SecretStr(os.environ["VAULT_TOKEN"])
-        logger.debug("Found Vault Token in environment variables")
         return _vault_token
 
     with suppress(FileNotFoundError):
@@ -243,14 +243,14 @@ def _extract_kubernetes(settings: BaseSettings) -> Optional[Kubernetes]:
 
         # Kubernetes role
         kubernetes_role: Optional[str] = None
+        if getattr(settings.__config__, "vault_kubernetes_role", None) is not None:
+            kubernetes_role = settings.__config__.vault_kubernetes_role  # type: ignore
+            logger.debug(f"Found Kubernetes role '{kubernetes_role}' in Config")
         if "VAULT_KUBERNETES_ROLE" in os.environ:
             kubernetes_role = os.environ["VAULT_KUBERNETES_ROLE"]
             logger.debug(
                 f"Found Kubernetes role '{kubernetes_role}' in environment variables"
             )
-        if getattr(settings.__config__, "vault_kubernetes_role", None) is not None:
-            kubernetes_role = settings.__config__.vault_kubernetes_role  # type: ignore
-            logger.debug(f"Found Kubernetes role '{kubernetes_role}' in Config")
 
         if kubernetes_role is not None:
             return Kubernetes(role=kubernetes_role, jwt_token=_kubernetes_jwt)

--- a/src/pydantic_vault/vault_settings.py
+++ b/src/pydantic_vault/vault_settings.py
@@ -209,6 +209,12 @@ def _extract_vault_token(settings: BaseSettings) -> Optional[SecretStr]:
         logger.debug("Found Vault Token in environment variables")
         return _vault_token
 
+    with suppress(FileNotFoundError):
+        with open(Path.home() / ".vault-token") as token_file:
+            _vault_token = SecretStr(token_file.read().strip())
+            logger.debug("Found Vault Token in file '~/.vault-token'")
+            return _vault_token
+
     if getattr(settings.__config__, "vault_token", None) is not None:
         if isinstance(settings.__config__.vault_token, SecretStr):  # type: ignore
             _vault_token = settings.__config__.vault_token  # type: ignore
@@ -216,12 +222,6 @@ def _extract_vault_token(settings: BaseSettings) -> Optional[SecretStr]:
             _vault_token = SecretStr(settings.__config__.vault_token)  # type: ignore
         logger.debug("Found Vault Token in Config")
         return _vault_token
-
-    with suppress(FileNotFoundError):
-        with open(Path.home() / ".vault-token") as token_file:
-            _vault_token = SecretStr(token_file.read().strip())
-            logger.debug("Found Vault Token in file '~/.vault-token'")
-            return _vault_token
 
     return None
 

--- a/tests/test_get_vault_client.py
+++ b/tests/test_get_vault_client.py
@@ -82,7 +82,7 @@ def test_get_vault_client_namespace_priority(
     mocker: MockerFixture, monkeypatch: MonkeyPatch
 ) -> None:
     """
-    Value in Config class should be preferred over environment variable VAULT_NAMESPACE
+    Environment variable VAULT_NAMESPACE should be preferred over value in Config class
     """
 
     class Settings(BaseSettings):
@@ -100,7 +100,7 @@ def test_get_vault_client_namespace_priority(
 
     _get_authenticated_vault_client(settings)
     vault_client_mock.assert_called_once_with(
-        "https://vault.tld", namespace="some/namespace/from/config"
+        "https://vault.tld", namespace="some/namespace/from/environment"
     )
 
 
@@ -194,7 +194,7 @@ def test_get_vault_client_vault_token_priority_env_config(
     mocker: MockerFixture, monkeypatch: MonkeyPatch
 ) -> None:
     """
-    Value in Config class should be preferred over environment variable VAULT_TOKEN
+    Environment variable VAULT_TOKEN should be preferred over value in Config class
     """
 
     class Settings(BaseSettings):
@@ -212,7 +212,7 @@ def test_get_vault_client_vault_token_priority_env_config(
 
     _get_authenticated_vault_client(settings)
     vault_client_mock.assert_called_once_with(
-        "https://vault.tld", token="fake-token-from-config"
+        "https://vault.tld", token="fake-token-from-environment"
     )
 
 
@@ -375,7 +375,7 @@ def test_get_vault_client_approle_priority_env_config(
     monkeypatch: MonkeyPatch,
 ) -> None:
     """
-    Values in Config class should be preferred over environment variables VAULT_ROLE_ID and VAULT_SECRET_ID
+    Environment variables VAULT_ROLE_ID and VAULT_SECRET_ID should be preferred over values in Config class
     """
 
     class Settings(BaseSettings):
@@ -396,7 +396,7 @@ def test_get_vault_client_approle_priority_env_config(
     _get_authenticated_vault_client(settings)
     vault_client_mock.assert_called_once_with("https://vault.tld")
     vault_client_mock.return_value.auth.approle.login.assert_called_once_with(
-        role_id="fake-role-id-from-config", secret_id="fake-secret-id-from-config"
+        role_id="fake-role-id-from-env", secret_id="fake-secret-id-from-env"
     )
 
 
@@ -461,7 +461,7 @@ def test_get_vault_client_approle_custom_auth_mount_point_priority_env_config(
     mocker: MockerFixture, monkeypatch: MonkeyPatch
 ) -> None:
     """
-    Value in Config class should be preferred over environment variable VAULT_AUTH_MOUNT_POINT
+    Environment variable VAULT_AUTH_MOUNT_POINT should be preferred over value in Config class
     """
 
     class Settings(BaseSettings):
@@ -484,7 +484,7 @@ def test_get_vault_client_approle_custom_auth_mount_point_priority_env_config(
     vault_client_mock.return_value.auth.approle.login.assert_called_once_with(
         role_id="fake-role-id",
         secret_id="fake-secret-id",
-        mount_point="custom-approle-from-config",
+        mount_point="custom-approle-from-env",
     )
 
 
@@ -533,7 +533,7 @@ def test_get_vault_client_vault_url_priority(
     mocker: MockerFixture, monkeypatch: MonkeyPatch
 ) -> None:
     """
-    Value in Config class should be preferred over environment variable VAULT_ADDR
+    Environment variable VAULT_ADDR should be preferred over value in Config class
     """
 
     class Settings(BaseSettings):
@@ -549,7 +549,7 @@ def test_get_vault_client_vault_url_priority(
     )
 
     _get_authenticated_vault_client(settings)
-    vault_client_mock.assert_called_once_with("https://vault-from-config.tld")
+    vault_client_mock.assert_called_once_with("https://vault-from-environment.tld")
 
 
 def test_get_vault_client_with_no_vault_url_fails() -> None:
@@ -623,7 +623,7 @@ def test_get_vault_client_with_kubernetes_token_role_priority_env_config(
     monkeypatch: MonkeyPatch,
 ) -> None:
     """
-    Value in Config class should be preferred over environment variable VAULT_KUBERNETES_ROLE
+    Environment variable VAULT_KUBERNETES_ROLE should be preferred over value in Config class
     """
 
     class Settings(BaseSettings):
@@ -642,7 +642,7 @@ def test_get_vault_client_with_kubernetes_token_role_priority_env_config(
     _get_authenticated_vault_client(settings)
     vault_client_mock.assert_called_once_with("https://vault.tld")
     vault_client_mock.return_value.auth.kubernetes.login.assert_called_once_with(
-        "my-role-from-config", mock_kubernetes_token_from_file
+        "my-role-from-env", mock_kubernetes_token_from_file
     )
 
 
@@ -712,7 +712,7 @@ def test_get_vault_client_kubernetes_custom_auth_mount_point_priority_env_config
     monkeypatch: MonkeyPatch,
 ) -> None:
     """
-    Value in Config class should be preferred over environment variable VAULT_AUTH_MOUNT_POINT
+    Environment variable VAULT_AUTH_MOUNT_POINT should be preferred over value in Config class
     """
 
     class Settings(BaseSettings):
@@ -734,7 +734,7 @@ def test_get_vault_client_kubernetes_custom_auth_mount_point_priority_env_config
     vault_client_mock.return_value.auth.kubernetes.login.assert_called_once_with(
         "my-role",
         mock_kubernetes_token_from_file,
-        mount_point="custom-kubernetes-from-config",
+        mount_point="custom-kubernetes-from-env",
     )
 
 
@@ -934,7 +934,7 @@ def test_get_vault_client_custom_ssl_priority(
     mocker: MockerFixture, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
 ) -> None:
     """
-    Value in Config class should be preferred over environment variable VAULT_CA_BUNDLE
+    Environment variable VAULT_CA_BUNDLE should be preferred over value in Config class
     """
 
     class Settings(BaseSettings):
@@ -953,7 +953,7 @@ def test_get_vault_client_custom_ssl_priority(
     _get_authenticated_vault_client(settings)
     vault_client_mock.assert_called_once_with(
         "https://vault.tld",
-        verify=False,
+        verify="/path/to/ca.crt",
     )
 
     # fmt: off

--- a/tests/test_get_vault_client.py
+++ b/tests/test_get_vault_client.py
@@ -957,6 +957,11 @@ def test_get_vault_client_custom_ssl_priority(
     )
 
     # fmt: off
-    assert ("pydantic-vault", logging.DEBUG, "Found Vault CA bundle '/path/to/ca.crt' in environment variables") in caplog.record_tuples
-    assert ("pydantic-vault", logging.DEBUG, "Found Vault CA bundle 'False' in Config") in caplog.record_tuples
+    ca_in_config_log = ("pydantic-vault", logging.DEBUG, "Found Vault CA bundle 'False' in Config")
+    ca_in_environment_log = ("pydantic-vault", logging.DEBUG, "Found Vault CA bundle '/path/to/ca.crt' in environment variables")
+
+    assert ca_in_config_log in caplog.record_tuples
+    assert ca_in_environment_log in caplog.record_tuples
+    # Ensure the Environment variable log happens after the other, so users know it was considered last and used
+    assert caplog.record_tuples.index(ca_in_config_log) < caplog.record_tuples.index(ca_in_environment_log)
     # fmt: on

--- a/tests/test_get_vault_client.py
+++ b/tests/test_get_vault_client.py
@@ -248,7 +248,7 @@ def test_get_vault_client_vault_token_priority_file_config(
     mock_vault_token_from_file: str,
 ) -> None:
     """
-    Value in Config class should be preferred over .vault-token file
+    .vault-token file should be preferred over value in Config class
     """
 
     class Settings(BaseSettings):
@@ -264,7 +264,7 @@ def test_get_vault_client_vault_token_priority_file_config(
 
     _get_authenticated_vault_client(settings)
     vault_client_mock.assert_called_once_with(
-        "https://vault.tld", token="fake-token-from-config"
+        "https://vault.tld", token="token-from-file"
     )
 
 


### PR DESCRIPTION
This change addresses issue https://github.com/nymous/pydantic-vault/issues/17 and changes the priorities of config sources as follows:
1. Environment variable
2. `.vault_token file` (for Vault token only)
3. Value specified in a Config class

This makes `pydantic-vault` consistent with [Pydantic](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#field-value-priority) and [12 Factor App](https://12factor.net/config).